### PR TITLE
setup.py python2.6 지원 수정 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     zip_safe=False,
     platforms='any',
     packages=find_packages(),
-    package_data={'':['templates/admin/*.html','templates/dmango/*.html']},
+    package_data={'':['templates/admin/*.html', 'templates/dmango/*.html']},
     install_requires=[
         'Flask >= 0.',
         'Flask-PyMongo >= 0.3.0',
@@ -22,7 +22,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
python2.6 dictionary comprehension 지원 안되기 때문에 몇몇 부분에서 
python setup.py install 시 에러발생하고 flask-dmango 설치 안되는 이슈 있음. 
python2.6 setup.py 에서 일단 뺌. 
